### PR TITLE
Fix Plugin Uninstall

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -67,7 +67,6 @@ class mg_qt_Uninstall {
 			'edit_others_quotes',
 			'publish_quotes',
 			'read_private_quotes',
-			'read',
 			'delete_quotes',
 			'delete_private_quotes',
 			'delete_published_quotes',


### PR DESCRIPTION
This PR fixes the plugin's uninstaller. See [here](https://wordpress.org/support/topic/login-error-after-plugin-deletion-you-do-not-have-sufficient-permissions/) for the issue.